### PR TITLE
Registering MetricRegistry with Application during run()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'spring-boot'
 apply plugin: 'groovy'
 apply plugin: 'signing'
 
-version = '2.0.1'
+version = '2.0.2'
 group = 'com.bericotech'
 
 

--- a/src/main/java/com/bericotech/fallwizard/FallwizardApplication.java
+++ b/src/main/java/com/bericotech/fallwizard/FallwizardApplication.java
@@ -47,13 +47,13 @@ public class FallwizardApplication<T extends FallwizardConfiguration> extends Ap
 
     @Override
     public void initialize(Bootstrap<T> bootstrap) {
-        applicationContext.getBeanFactory().registerResolvableDependency(MetricRegistry.class, bootstrap.getMetricRegistry());
     }
 
     @Override
     public void run(T configuration, Environment environment) throws Exception {
 
-        logger.info("Starting up FallWizardService");
+        logger.info("Starting up FallwizardApplication");
+        applicationContext.getBeanFactory().registerResolvableDependency(MetricRegistry.class, environment.metrics());
 
         // Populate the applicationContext based on the Spring Configuration
         initSpringConfig(configuration.getSpringConfiguration(),environment);


### PR DESCRIPTION
migrated from https://github.com/Berico-Technologies/Fallwizard/pull/16

DW 0.7.1 fixed the issue of 0.7.0 in which the internal DW MetricRegistry wasn't easily accessible
Enabling to access it in the run() 
by that removing the need for calling the super() on your own initalize method - which is a "gotcha! " 
